### PR TITLE
Fix links in the main layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,8 @@
 		<ul>
 			<li class="category">Social</li>
 			<li><a href="http://vk.com/crash_ap">Vk</a></li>
-			<li><a href="https://github.com/frozencrash"></a>GitHub</li>
-			<li><a href="mailto:zzcrash@gmail.com"></a>Email</li>
+			<li><a href="https://github.com/frozencrash">GitHub</a></li>
+			<li><a href="mailto:zzcrash@gmail.com">Email</a></li>
 		</ul>
 		
 		<p class="sign_in">Admin Login</p>


### PR DESCRIPTION
Correct Email and Github links by moving the link text in-between opening/closing brackets for <a> tag.
